### PR TITLE
Editor: temporarily fix hardbreak output from Nib convertFromHTML

### DIFF
--- a/client/components/Slide/Components/Text/Editor.jsx
+++ b/client/components/Slide/Components/Text/Editor.jsx
@@ -25,7 +25,7 @@ class TextEditor extends React.Component {
         const hasWrapper = /^(<.+>.*<\/.+>)$/gm.test(defaultHtml);
         const defaultValue = convertFromHTML(
             hasWrapper ? defaultHtml : `<p>${defaultHtml}</p>`
-        );
+        ).replace(/<br ><br><\/br>/gm, '<br>');
 
         this.onChange = this.onChange.bind(this);
         this.state = {


### PR DESCRIPTION
Preferred fix: https://github.com/nib-edit/Nib/pull/90 (and for more details)