### PR TITLE
Cohort scenario list layout

### DIFF
--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -9,13 +9,21 @@
   margin-bottom: 1rem;
 }
 
-.c__cohort-url {
-  margin-bottom: 1rem;
+.c__section {
+  margin-bottom: 3rem;
+}
+
+.c__header {
+  margin-bottom: 0 !important;
+}
+
+.c__subheader {
+  font-size: 1.2rem;
 }
 
 .c__cohort-url .ui.button {
   display: block;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
 }
 
 .c__cohort-url .ui.input input[type="text"] {

--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -10,15 +10,12 @@
 }
 
 .c__section {
-  margin-bottom: 3rem;
+  margin: 0 auto 3rem auto;
+  max-width: 70rem;
 }
 
-.c__header {
-  margin-bottom: 0 !important;
-}
-
-.c__subheader {
-  font-size: 1.2rem;
+.c__scenario-header-num span {
+  font-weight: bold;
 }
 
 .c__cohort-url .ui.button {
@@ -30,11 +27,48 @@
   width: 100%;
 }
 
+.c__scenario-card {
+  align-items: center;
+  display: grid !important;
+  grid-column-gap: 1rem;
+  grid-template-columns: 2fr 1fr;
+  width: 100% !important;
+}
+
+.c__scenario-card .meta:not(:empty) {
+  margin-top: 1rem;
+}
+
+.c__scenario-card.ui.card .meta * {
+  margin-bottom: 0.5rem;
+}
+
+.c__scenario-extra {
+  padding: 1rem;
+}
+
+.c__scenario-extra button {
+  width: 100%;
+}
+
+.c__scenario-list {
+  padding: 0;
+}
+
+.c__scenario-container {
+  background-color: var(--color-gray);
+  padding: 1rem;
+}
+
 @media only screen and (max-width: 767px) {
   .ui.container.c__table-container {
     width: auto !important;
     margin-left: 0em !important;
     margin-right: 0em !important;
+  }
+
+  .c__scenario-card {
+    display: block !important;
   }
 }
 

--- a/client/components/Cohorts/Cohort.css
+++ b/client/components/Cohorts/Cohort.css
@@ -9,6 +9,19 @@
   margin-bottom: 1rem;
 }
 
+.c__cohort-url {
+  margin-bottom: 1rem;
+}
+
+.c__cohort-url .ui.button {
+  display: block;
+  margin-top: 1rem;
+}
+
+.c__cohort-url .ui.input input[type="text"] {
+  width: 100%;
+}
+
 @media only screen and (max-width: 767px) {
   .ui.container.c__table-container {
     width: auto !important;

--- a/client/components/Cohorts/Cohort.jsx
+++ b/client/components/Cohorts/Cohort.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Icon, Menu, Segment, Title } from '@components/UI';
+import { Button, Icon, Input, Menu, Segment, Title } from '@components/UI';
 import copy from 'copy-text-to-clipboard';
 import Storage from '@utils/Storage';
 import { getCohort, linkUserToCohort } from '@actions/cohort';
@@ -172,16 +172,20 @@ export class Cohort extends React.Component {
     // Everytime there is a render, save the state.
     Storage.set(this.sessionKey, { activeTabKey, tabs });
 
-    const menuItemCopyUrl = (
-      <Menu.Item.Tabbable
-        key="menu-item-account-administration"
+    const menuItemShowCohortUrl = (
+      <Input label="Cohort url" size="big" type="text" defaultValue={url} />
+    );
+
+    const menuItemCopyCohortUrl = (
+      <Button
+        icon
+        labelPosition="left"
+        size="small"
         onClick={onCohortUrlCopyClick}
       >
-        <Icon.Group className="em__icon-group-margin">
-          <Icon name="clipboard outline" />
-        </Icon.Group>
+        <Icon name="clipboard outline" color="blue" />
         Copy cohort link to clipboard
-      </Menu.Item.Tabbable>
+      </Button>
     );
 
     return (
@@ -214,9 +218,9 @@ export class Cohort extends React.Component {
         {activeTabKey === 'cohort' ? (
           <Segment attached="bottom">
             {isFacilitator ? (
-              <Menu icon borderless>
-                {menuItemCopyUrl}
-              </Menu>
+              <div className="c__cohort-url">
+                {menuItemShowCohortUrl} {menuItemCopyCohortUrl}
+              </div>
             ) : null}
             <CohortScenarios
               key="cohort-scenarios"

--- a/client/components/Cohorts/Cohort.jsx
+++ b/client/components/Cohorts/Cohort.jsx
@@ -2,7 +2,15 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Button, Icon, Input, Menu, Segment, Title } from '@components/UI';
+import {
+  Button,
+  Header,
+  Icon,
+  Input,
+  Menu,
+  Segment,
+  Title
+} from '@components/UI';
 import copy from 'copy-text-to-clipboard';
 import Storage from '@utils/Storage';
 import { getCohort, linkUserToCohort } from '@actions/cohort';
@@ -218,16 +226,24 @@ export class Cohort extends React.Component {
         {activeTabKey === 'cohort' ? (
           <Segment attached="bottom">
             {isFacilitator ? (
-              <div className="c__cohort-url">
+              <section className="c__section c__cohort-url">
                 {menuItemShowCohortUrl} {menuItemCopyCohortUrl}
-              </div>
+              </section>
             ) : null}
-            <CohortScenarios
-              key="cohort-scenarios"
-              id={cohort.id}
-              authority={authority}
-              onClick={onClick}
-            />
+            <section className="c__section">
+              <Header className="c__header" as="h2">
+                Cohort scenarios
+              </Header>
+              <p className="c__subheader">
+                Manage your assigned scenarios and see your cohort responses.
+              </p>
+              <CohortScenarios
+                key="cohort-scenarios"
+                id={cohort.id}
+                authority={authority}
+                onClick={onClick}
+              />
+            </section>
             {isFacilitator ? (
               <CohortParticipants
                 key="cohort-participants"

--- a/client/components/Cohorts/Cohort.jsx
+++ b/client/components/Cohorts/Cohort.jsx
@@ -234,9 +234,6 @@ export class Cohort extends React.Component {
               <Header className="c__header" as="h2">
                 Cohort scenarios
               </Header>
-              <p className="c__subheader">
-                Manage your assigned scenarios and see your cohort responses.
-              </p>
               <CohortScenarios
                 key="cohort-scenarios"
                 id={cohort.id}


### PR DESCRIPTION
This PR adds a visual layer to some of the components in the cohort detail page:
* Adds visual url for cohort link (as well as maintains the copy to clipboard functionality)
* Separates out first sections
* Adds visual layer (and card restructure) of scenario list

There are some items here that essentially break the user experience but can be reconfigured once we have in the functionality to edit the scenario list in a modal.